### PR TITLE
Use node VM module to evaluate node-gyp-build paths.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 const {OriginalSource, SourceMapSource, ReplaceSource} = require("webpack-sources");
 const {dirname, relative, resolve: path_resolve} = require('path');
+const {runInNewContext} = require('vm');
 
 function _bindings(loader, match, code)
 {
@@ -47,9 +48,10 @@ function _node_gyp_build(loader, match, code)
             {
                 const node_module = require(module_path);
 
-                let args = dirname(loader.resourcePath);
-                if(match[1] !== '__dirname')
-                    args = path_resolve(args, match[1])
+                const args = runInNewContext(match[1], {
+                    __dirname: dirname(loader.resourcePath),
+                    __filename: loader.resourcePath,
+                });
 
                 const resolve_path = relative(dirname(loader.resourcePath), node_module.path(args)).replace(/\\/g, '/');
                 code.replace(match.index, match.index + match[0].length - 1, `require('./${resolve_path}')`);


### PR DESCRIPTION
This is essentially eval(), but lets us provide the context values, like
__dirname. This makes requests like `require('node-gyp-build')(__dirname + '/..')` work, but not `...(path.dirname(__dirname))`.

Could use the same for bindings, but I don't have anything to test with
in my current project.